### PR TITLE
allow nullable matcher pattern for `hasPattern`

### DIFF
--- a/src/main/scala/com/amazon/deequ/analyzers/PatternMatch.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/PatternMatch.scala
@@ -46,7 +46,11 @@ case class PatternMatch(column: String, pattern: Regex, where: Option[String] = 
   }
 
   override def aggregationFunctions(): Seq[Column] = {
-    val expression = when(col(column).rlike(pattern.toString) === lit(true), 1).otherwise(0)
+    val expression =
+      when((col(column).rlike(pattern.toString) ||
+            col(column).isNull) // ignore null values
+            === lit(true),
+            1).otherwise(0)
 
     val summation = sum(conditionalSelection(expression, where).cast(IntegerType))
 

--- a/src/main/scala/com/amazon/deequ/analyzers/PatternMatch.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/PatternMatch.scala
@@ -19,7 +19,7 @@ package com.amazon.deequ.analyzers
 import com.amazon.deequ.analyzers.Analyzers._
 import com.amazon.deequ.analyzers.Preconditions.{hasColumn, isString}
 import org.apache.spark.sql.{Column, Row}
-import org.apache.spark.sql.functions.{col, lit, regexp_extract, sum, when}
+import org.apache.spark.sql.functions.{col, lit, sum, when}
 import org.apache.spark.sql.types.{IntegerType, StructType}
 
 import scala.util.matching.Regex
@@ -46,9 +46,7 @@ case class PatternMatch(column: String, pattern: Regex, where: Option[String] = 
   }
 
   override def aggregationFunctions(): Seq[Column] = {
-
-    val expression = when(regexp_extract(col(column), pattern.toString(), 0) =!= lit(""), 1)
-      .otherwise(0)
+    val expression = when(col(column).rlike(pattern.toString) === lit(true), 1).otherwise(0)
 
     val summation = sum(conditionalSelection(expression, where).cast(IntegerType))
 

--- a/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
+++ b/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
@@ -644,6 +644,23 @@ class CheckTest extends AnyWordSpec with Matchers with SparkContextSpec with Fix
       assertEvaluatesTo(check, context, CheckStatus.Success)
     }
 
+    "ignore null values for hasPattern constraints" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val df = Seq(
+        ("123", 1),
+        (null, 2),
+        ("456", 1)
+      ).toDF("nullable", "id")
+
+      val check = Check(CheckLevel.Error, "some description")
+        .hasPattern("nullable", "\\d{3,3}".r, _ == 1.0)
+
+      val context = runChecks(df, check)
+
+      assertEvaluatesTo(check, context, CheckStatus.Success)
+    }
+
     "fail on mixed data for E-Mail pattern with default assertion" in withSparkSession { session =>
       val col = "some"
       val df = dataFrameWithColumn(col, StringType, session, Row("someone@somewhere.org"),

--- a/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
+++ b/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
@@ -626,6 +626,24 @@ class CheckTest extends AnyWordSpec with Matchers with SparkContextSpec with Fix
       assertEvaluatesTo(check, context, CheckStatus.Success)
     }
 
+    "allow regular expression pattern to match for empty strings" in withSparkSession { spark =>
+      import spark.implicits._
+
+      // XXX `id` is needed, otherwise scalastyle will complain due to the bug below
+      // https://github.com/scalastyle/scalastyle/issues/195
+      val df = Seq(
+        ("123", 1),
+        ("", 2)
+      ).toDF("maybeempty", "id")
+
+      val check = Check(CheckLevel.Error, "some description")
+        .hasPattern("maybeempty", "(|\\d{3,3})".r, _ == 1.0)
+
+      val context = runChecks(df, check)
+
+      assertEvaluatesTo(check, context, CheckStatus.Success)
+    }
+
     "fail on mixed data for E-Mail pattern with default assertion" in withSparkSession { session =>
       val col = "some"
       val df = dataFrameWithColumn(col, StringType, session, Row("someone@somewhere.org"),


### PR DESCRIPTION
*Issue #, if available:*

Currently `.hasPattern`
1.always fails for `null` values
2. doesn't allow a patterns that can match empty strings

*Description of changes:*

1. we will ignore `null` values in `PatternMatch` checks
2. we will use `.rlike` instead of `regexp_extract`, which can match empty strings 
   (well, `regexp_extract` can actually match empty strings, but we can't tell the difference between it and match failure, because `regexp_extract`'s return is '""' when the match failed)

The added test should explain the use case of this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
